### PR TITLE
ulislaw tikers sleep

### DIFF
--- a/TESTS/mbed_drivers/lp_ticker/main.cpp
+++ b/TESTS/mbed_drivers/lp_ticker/main.cpp
@@ -33,9 +33,9 @@ static const int test_timeout = 10;
 /* Due to poor accuracy of LowPowerTicker on many platforms
    there is no sense to tune tolerance value as it was in Ticker tests.
 
-   Tolerance value is set to 500us for measurement inaccuracy + 5% tolerance
+   Tolerance value is set to 600us for measurement inaccuracy + 5% tolerance
    for LowPowerTicker. */
-#define TOLERANCE_US(DELAY) (500 + DELAY / 20)
+#define TOLERANCE_US(DELAY) (600 + DELAY / 20)
 
 
 volatile uint32_t ticker_callback_flag;

--- a/TESTS/mbed_drivers/timerevent/main.cpp
+++ b/TESTS/mbed_drivers/timerevent/main.cpp
@@ -39,6 +39,8 @@ private:
 public:
     TestTimerEvent() :
             TimerEvent(), sem(0, 1) {
+
+        sleep_manager_lock_deep_sleep();
     }
 
     TestTimerEvent(const ticker_data_t *data) :
@@ -46,6 +48,7 @@ public:
     }
 
     virtual ~TestTimerEvent() {
+        sleep_manager_unlock_deep_sleep();
     }
 
     // Make these methods publicly accessible

--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -443,6 +443,8 @@ utest::v1::status_t us_ticker_setup(const Case *const source, const size_t index
 {
     intf = get_us_ticker_data()->interface;
 
+    OS_Tick_Disable();
+
     intf->init();
 
     prev_irq_handler = set_us_ticker_irq_handler(ticker_event_handler_stub);
@@ -459,6 +461,8 @@ utest::v1::status_t us_ticker_teardown(const Case * const source, const size_t p
 
     prev_irq_handler = NULL;
 
+    OS_Tick_Enable();
+
     return greentea_case_teardown_handler(source, passed, failed, reason);
 }
 
@@ -466,6 +470,8 @@ utest::v1::status_t us_ticker_teardown(const Case * const source, const size_t p
 utest::v1::status_t lp_ticker_setup(const Case *const source, const size_t index_of_case)
 {
     intf = get_lp_ticker_data()->interface;
+
+    OS_Tick_Disable();
 
     intf->init();
 
@@ -482,6 +488,8 @@ utest::v1::status_t lp_ticker_teardown(const Case * const source, const size_t p
     set_lp_ticker_irq_handler(prev_irq_handler);
 
     prev_irq_handler = NULL;
+
+    OS_Tick_Enable();
 
     return greentea_case_teardown_handler(source, passed, failed, reason);
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/sleep.c
@@ -18,12 +18,16 @@
 #include "mbed_interface.h"
 #include "softdevice_handler.h"
 #include "nrf_soc.h"
+#include "nrf_timer.h"
+#include "us_ticker.h"
 
 // Mask of reserved bits of the register ICSR in the System Control Block peripheral
 // In this case, bits which are equal to 0 are the bits reserved in this register
 #define SCB_ICSR_RESERVED_BITS_MASK     0x9E43F03F
 
 #define FPU_EXCEPTION_MASK 0x0000009F
+
+extern bool us_ticker_initialized;
 
 void hal_sleep(void)
 {
@@ -75,6 +79,15 @@ void hal_sleep(void)
 
 void hal_deepsleep(void)
 {
+    if (us_ticker_initialized) {
+        nrf_timer_task_trigger(NRF_TIMER1, NRF_TIMER_TASK_STOP);
+    }
+
     hal_sleep();
+
+    if (us_ticker_initialized) {
+        nrf_timer_task_trigger(NRF_TIMER1, NRF_TIMER_TASK_START);
+    }
+
     //   NRF_POWER->SYSTEMOFF=1;
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/us_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/us_ticker.c
@@ -44,7 +44,7 @@
 #include "nrf_drv_common.h"
 #include "mbed_critical.h"
 
-static bool us_ticker_initialized = false;
+bool us_ticker_initialized = false;
 
 /* us ticker is driven by 1MHz clock and counter length is 16 bits. */
 const ticker_info_t* us_ticker_get_info()

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2497,7 +2497,7 @@
     "DELTA_DFCM_NNN50": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
-        "device_has": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "device_has": ["USTICKER", "LPTICKER", "ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
         "device_name": "nRF51822_xxAC"
     },
     "DELTA_DFCM_NNN50_BOOT": {
@@ -2594,7 +2594,7 @@
     },
     "MTB_LAIRD_BL600": {
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
-        "device_has": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "device_has": ["USTICKER", "LPTICKER", "ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
         "device_name": "nRF51822_xxAA",
         "release_versions" : ["5"],
         "extra_labels_add": ["MTB_LAIRD_BL600"],
@@ -2620,7 +2620,7 @@
     "TY51822R3": {
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
         "macros_add": ["TARGET_NRF_32MHZ_XTAL"],
-        "device_has": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "device_has": ["USTICKER", "LPTICKER", "ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
         "detect_code": ["1019"],
         "release_versions": ["2", "5"],
         "overrides": {"uart_hwfc": 0},
@@ -3500,7 +3500,7 @@
                 "macro_name": "MBED_CONF_NORDIC_UART_HWFC"
             }
         },
-        "device_has": ["USTICKER", "LPTICKER", "ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"]
+        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"]
     },
     "MCU_NRF51_32K_UNIFIED": {
         "inherits": ["MCU_NRF51_UNIFIED"],
@@ -3511,20 +3511,20 @@
     "NRF51_DK": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
-        "device_has": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "device_has": ["USTICKER", "LPTICKER", "ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
         "release_versions": ["2", "5"],
         "device_name": "nRF51822_xxAA"
     },
     "NRF51_DONGLE": {
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
         "progen": {"target": "nrf51-dongle"},
-        "device_has": ["I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "device_has": ["USTICKER", "LPTICKER", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
         "release_versions": ["2", "5"]
     },
     "OSHCHIP": {
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
         "overrides": {"lf_clock_src": "NRF_LF_SRC_RC"},
-        "device_has": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
+        "device_has": ["USTICKER", "LPTICKER", "ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "device_name": "nRF51822_xxAC"
     },
     "MCU_NRF52832": {
@@ -3902,7 +3902,7 @@
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
         "detect_code": ["C006"],
         "overrides": {"uart_hwfc": 0},
-        "device_has": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "device_has": ["USTICKER", "LPTICKER", "ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
         "release_versions": ["2"],
         "device_name": "nRF51822_xxAC"
     },


### PR DESCRIPTION
## Description

Provide the following changes:
- Disable us ticker in deep-sleep mode if running (make it consistent with sleep requirements). Verified that hal sleep test from feature-hal-spec-sleep branch passes.
- Update tests-mbed_drivers-timerevent(see commit comment).
- Modify tolerance in tests-mbed_drivers-lp_ticker (see commit comment).
- Enable all NRF51 boards which are enabled on current master (previous version was invalid and PR has been merged before I pushed the fix).

## Status
**READY**


## Migrations
NO
